### PR TITLE
Fix RSS currently using localhost:8000

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -23,7 +23,7 @@ COVER_IMG_URL = '/theme/sidebar.jpg'
 
 SOCIAL = (
     ('envelope', 'mailto:rest-at-sea@trunat.fr'),
-    ('rss', SITEURL + '/feeds/all.atom.xml'),
+    ('rss', '/feeds/all.atom.xml'),
     ('facebook', 'https://www.facebook.com/pg/remymini433/'),
     ('github', 'https://github.com/Natim/rest-sea'),
 )


### PR DESCRIPTION
RSS on prod redirect to SITEURL which is currently localhost:8000. 
An easy none intrusive fix could be to remove the SITEURL value from rss making the absolute url now a relative one 👍.
Alternative solution is updating SITEURL value but that might have side effects 😆.